### PR TITLE
Use "capi" release to detect cf deployment name

### DIFF
--- a/toolsmiths/claim-pooled-env/claimed-env-helpers.sh
+++ b/toolsmiths/claim-pooled-env/claimed-env-helpers.sh
@@ -40,5 +40,5 @@ bosh-login() {
 }
 
 get-cf-deployment-name() {
-  bosh deployments --json | jq -r '.Tables[].Rows | map(select(.release_s | contains("garden-runc"))) | .[0].name'
+  bosh deployments --json | jq -r '.Tables[].Rows | map(select(.release_s | contains("capi"))) | .[0].name'
 }


### PR DESCRIPTION
garden-runc is also included in isolation-segment deployments, so use capi, which is unique to the cf deployment.